### PR TITLE
documentation updates to reflect @technoweenie's change on master

### DIFF
--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -8,7 +8,7 @@
 #
 # Use like so:
 #
-#   @syntaxer = Albino.new('/some/file.rb', :ruby)
+#   @syntaxer = Albino.new('puts "Hello World"', :ruby)
 #   puts @syntaxer.colorize
 #
 # This'll print out an HTMLized, Ruby-highlighted version
@@ -16,12 +16,16 @@
 #
 # To use another formatter, pass it as the third argument:
 #
-#   @syntaxer = Albino.new('/some/file.rb', :ruby, :bbcode)
+#   @syntaxer = Albino.new('puts "Hello World"', :ruby, :bbcode)
 #   puts @syntaxer.colorize
 #
 # You can also use the #colorize class method:
 #
-#   puts Albino.colorize('/some/file.rb', :ruby)
+#   puts Albino.colorize('puts "Hello World"', :ruby)
+#
+# To format a file, pass a file stream:
+#
+#   puts Albino.colorize(File.new('/some/file.rb'), :ruby)
 #
 # Another also: you get a #to_s, for somewhat nicer use in Rails views.
 #


### PR DESCRIPTION
so that I am no longer confused, wondering why Ruby strings `respond_to?(:read)` in Albino but not irb :-)
