### PR TITLE
Fixed a write_nonblock issue when dealing with multi-byte characters

### DIFF
--- a/lib/albino/process.rb
+++ b/lib/albino/process.rb
@@ -158,16 +158,11 @@ class Albino
         # write to stdin stream
         ready[1].each do |fd|
           begin
-            boom = nil
-            size = fd.write_nonblock(input)
-            input = input[size, input.size]
-          rescue Errno::EPIPE => boom
-          rescue Errno::EAGAIN, Errno::EINTR
+            fd.write(input)
+          rescue Errno::EPIPE, Errno::EAGAIN, Errno::EINTR
           end
-          if boom || input.size == 0
-            stdin.close
-            writers.delete(stdin)
-          end
+          stdin.close
+          writers.delete(stdin)
         end
 
         # read from stdout and stderr streams

--- a/test/process_test.rb
+++ b/test/process_test.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'albino'
 require 'rubygems'
 require 'test/unit'
@@ -45,6 +46,12 @@ class TestProcess < Test::Unit::TestCase
 
   def test_input
     input = "HEY NOW\n" * 100_000 # 800K
+    p = Albino::Process.new(['wc', '-l'], {}, :input => input)
+    assert_equal 100_000, p.out.strip.to_i
+  end
+  
+  def test_utf8_input
+    input = "smörgåsbord\n" * 100_000
     p = Albino::Process.new(['wc', '-l'], {}, :input => input)
     assert_equal 100_000, p.out.strip.to_i
   end


### PR DESCRIPTION
I'm not sure if this is the best solution, but it seemed to work well for me so I thought I'd start a pull request and get some feedback on it (or have it accepted).

In the `read_and_write` method within Process:

```
begin
  boom = nil
  size = fd.write_nonblock(input)
  input = input[size, input.size]
rescue Errno::EPIPE => boom
rescue Errno::EAGAIN, Errno::EINTR
end
if boom || input.size == 0
  stdin.close
  writers.delete(stdin)
end
```

I came across an issue while messing around with the Twitter API and multi-byte characters returned within tweets. `fd.write_nonblock` returns the number of **BYTES** written, not the number of **CHARS**. This becomes an issue when slicing the `input` string since the numbers differ if multi-byte characters are included. In my specific case, there was only a single multi-byte char and therefore it was trying to slice as `input[2382, 2380]` which returns nil.
My solution was to use `fd.write` instead, even though it could block. I haven't noticed any performance degradation yet. Let me know what you think about this approach, or enlighten me if you have a better one!

Thanks,
- Adam
