### PR TITLE
Added the ability to include options for the formatter

### DIFF
--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -73,7 +73,7 @@ class Albino
     new(*args).colorize
   end
 
-  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding, options)
+  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding, options = "")
     @target  = target
     @options = { :l => lexer, :f => format}
     if options


### PR DESCRIPTION
I really liked how this gem worked but was so limited by the formatter, what about line numbers, anchor tags, line spacing.  all of these things are great parts.

I added 1 more param to the initialize method so you can pass options to it and a simple if statement to handle a default case.

Usage example would be 

Albino.colorize(pre.text.rstrip, pre[:lang], :html, 'utf-8', "linenos=False,lineanchors=line")
