### PR TITLE
Added code to allow options in the formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ For this and other extractions, see [http://github.com/github]()
     @syntaxer = Albino.new(File.new('albino.rb'), :ruby, :bbcode)
     puts @syntaxer.colorize
 
+## You can also include options for the parser
+
+    require 'albino'
+    Albino.colorize('puts "Hello World"', :ruby, :html, 'utf-8', "linenos=True")
+
 ### Multi
 
     require 'albino/multi'

--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -73,9 +73,14 @@ class Albino
     new(*args).colorize
   end
 
-  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding)
+  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding, options)
     @target  = target
-    @options = { :l => lexer, :f => format, :O => "encoding=#{encoding}" }
+    @options = { :l => lexer, :f => format}
+    if options
+      @options[:O] = "encoding=#{encoding}"+options
+    else
+      @options[:O] = "encoding=#{encoding},linenos=table,lineanchors=line"
+    end
     @encoding = encoding
   end
 

--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -77,9 +77,9 @@ class Albino
     @target  = target
     @options = { :l => lexer, :f => format}
     if options
-      @options[:O] = "encoding=#{encoding}"+options
+      @options[:O] = "encoding=#{encoding},"+options
     else
-      @options[:O] = "encoding=#{encoding},linenos=table,lineanchors=line"
+      @options[:O] = "encoding=#{encoding}"
     end
     @encoding = encoding
   end

--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -73,7 +73,7 @@ class Albino
     new(*args).colorize
   end
 
-  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding, options)
+  def initialize(target, lexer = :text, format = :html, encoding = self.class.default_encoding, options = "")
     @target  = target
     @options = { :l => lexer, :f => format}
     if options


### PR DESCRIPTION
I really liked how this gem worked but was so limited by the formatter, what about line numbers, anchor tags, line spacing. all of these things are great parts.

I added 1 more param to the initialize method so you can pass options to it and a simple if statement to handle a default case.

Usage example would be

Albino.colorize(pre.text.rstrip, pre[:lang], :html, 'utf-8', "linenos=False,lineanchors=line")
