### PR TITLE
Cannot use hl_lines parameter

### DIFF
--- a/lib/albino.rb
+++ b/lib/albino.rb
@@ -117,11 +117,11 @@ class Albino
     end
   end
 
-  def validate_shell_args(flag, value)
+    def validate_shell_args(flag, value)
     if flag !~ /^[a-z]+$/i
       raise ShellArgumentError, "Flag is invalid: #{flag.inspect}"
     end
-    if value !~ /^[a-z0-9\-\_\+\=\#\,\s]+$/i
+    if value !~ /^[a-z0-9"\-\_\+\=\#\,\s]+$/i
       raise ShellArgumentError, "Flag value is invalid: -#{flag} #{value.inspect}"
     end
   end


### PR DESCRIPTION
I am not able to use hl_lines parameter since this parameter involves using quotation marks such as follows when using Jekyll:

{ % highlight ruby hl_lines="2 3 4" }

However, using quotation marks in the value parameter is considered invalid as per the regular expression.
